### PR TITLE
SRA should be annotated as signed

### DIFF
--- a/Five-Stage-Datapath.srcs/modules/execution/ArithmeticLogicUnit.v
+++ b/Five-Stage-Datapath.srcs/modules/execution/ArithmeticLogicUnit.v
@@ -11,8 +11,8 @@
 module ArithmeticLogicUnit(
     // Inputs
     input [3:0] aluControl,
-    signed input [31:0] a,
-    signed input [31:0] b,
+    input signed [31:0] a,
+    input signed [31:0] b,
     // Outputs
     output reg [31:0] out
     );
@@ -37,7 +37,7 @@ module ArithmeticLogicUnit(
             4'b0111: // SRL
                 out = b >> a;
             4'b1111: // SRA
-                out = $signed(b >>> a);
+                out = b >>> a;
         endcase
     end
 endmodule

--- a/Five-Stage-Datapath.srcs/modules/execution/ArithmeticLogicUnit.v
+++ b/Five-Stage-Datapath.srcs/modules/execution/ArithmeticLogicUnit.v
@@ -11,8 +11,8 @@
 module ArithmeticLogicUnit(
     // Inputs
     input [3:0] aluControl,
-    input [31:0] a,
-    input [31:0] b,
+    signed input [31:0] a,
+    signed input [31:0] b,
     // Outputs
     output reg [31:0] out
     );
@@ -37,7 +37,7 @@ module ArithmeticLogicUnit(
             4'b0111: // SRL
                 out = b >> a;
             4'b1111: // SRA
-                out = b >>> a;
+                out = $signed(b >>> a);
         endcase
     end
 endmodule


### PR DESCRIPTION
In the README screenshot for the shifts subroutine, the writeback value for `sra $t0, $t0, 16` where `$t0 = 32'h80000000` is `32'h00008000`. Since we're performing an `sra`, the value should be `32'hFFFF8000`. Apparently, this can be fixed with a `$signed` annotation.

https://camo.githubusercontent.com/e70033f5f4162745d90f365583154eb17fb1dfb7cf13de3076b3a97464de0cbc/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f3338353538313030393635333230323934352f3734333334313535343931353231333334322f756e6b6e6f776e2e706e67

Not tested locally.